### PR TITLE
Bug/Saving linked datasets

### DIFF
--- a/maps/GWDM/2.0/HDRUK/3.0.0/translation.jsonata
+++ b/maps/GWDM/2.0/HDRUK/3.0.0/translation.jsonata
@@ -28,10 +28,10 @@ $joinTypicalAgeRange := function($min, $max){(
 
 $getDatasetLinkage := function() {(
     $datasetLinkage := {
-        "isDerivedFrom": $join($map(input.enrichmentAndLinkage.derivedFrom, function($v) { $v.url ? $v.url : $v.title }), ", "),
-        "isPartOf": $join($map(input.enrichmentAndLinkage.isPartOf, function($v) { $v.url ? $v.url : $v.title }), ", "),
-        "isMemberOf": $join($map(input.enrichmentAndLinkage.similarToDatasets, function($v) { $v.url ? $v.url : $v.title }), ", "),
-        "linkedDatasets": $join($map(input.enrichmentAndLinkage.linkableDatasets, function($v) { $v.url ? $v.url : $v.title }), ", ")
+        "isDerivedFrom": $join($map(input.enrichmentAndLinkage.derivedFrom, function($v) { $v.url ? $v.url : $v.title }), ";,;"),
+        "isPartOf": $join($map(input.enrichmentAndLinkage.isPartOf, function($v) { $v.url ? $v.url : $v.title }), ";,;"),
+        "isMemberOf": $join($map(input.enrichmentAndLinkage.similarToDatasets, function($v) { $v.url ? $v.url : $v.title }), ";,;"),
+        "linkedDatasets": $join($map(input.enrichmentAndLinkage.linkableDatasets, function($v) { $v.url ? $v.url : $v.title }), ";,;")
     };
     $count($filter($datasetLinkage, function($v) { $v != null })) = 0 ? null : $datasetLinkage
 )};

--- a/maps/GWDM/2.0/HDRUK/3.0.0/translation.jsonata
+++ b/maps/GWDM/2.0/HDRUK/3.0.0/translation.jsonata
@@ -26,14 +26,14 @@ $joinTypicalAgeRange := function($min, $max){(
     $minStr ? $maxStr ? $join([$minStr, "-", $maxStr]) : null : null
 )};
 
-$getDatasetLinkage := function(){(
+$getDatasetLinkage := function() {(
     $datasetLinkage := {
-      "isDerivedFrom":$to_str(input.enrichmentAndLinkage.derivedFrom),
-      "isPartOf":$to_str(input.enrichmentAndLinkage.isPartOf),
-      "isMemberOf": $to_str(input.enrichmentAndLinkage.similarToDatasets),
-      "linkedDatasets":$to_str(input.enrichmentAndLinkage.linkableDatasets)
+        "isDerivedFrom": $join($map(input.enrichmentAndLinkage.derivedFrom, function($v) { $v.url ? $v.url : $v.title }), ", "),
+        "isPartOf": $join($map(input.enrichmentAndLinkage.isPartOf, function($v) { $v.url ? $v.url : $v.title }), ", "),
+        "isMemberOf": $join($map(input.enrichmentAndLinkage.similarToDatasets, function($v) { $v.url ? $v.url : $v.title }), ", "),
+        "linkedDatasets": $join($map(input.enrichmentAndLinkage.linkableDatasets, function($v) { $v.url ? $v.url : $v.title }), ", ")
     };
-    $datasetLinkage = {} ? null : $datasetLinkage
+    $count($filter($datasetLinkage, function($v) { $v != null })) = 0 ? null : $datasetLinkage
 )};
 
 $getOrigin := function(){(

--- a/maps/HDRUK/3.0.0/GWDM/2.0/translation.jsonata
+++ b/maps/HDRUK/3.0.0/GWDM/2.0/translation.jsonata
@@ -322,7 +322,7 @@ $getDatasetLinkage := function($outputField,$inputField) {
     $defaultValue(
         $outputField,
         $map(
-            $split($inputField, ";,;"),
+            $inputField ? $split($inputField, ";,;") : [],
             function($item) { 
                 {
                     "pid": null, 

--- a/maps/HDRUK/3.0.0/GWDM/2.0/translation.jsonata
+++ b/maps/HDRUK/3.0.0/GWDM/2.0/translation.jsonata
@@ -318,6 +318,22 @@ $getMaterialType := function($tissue){
     $tissue.materialType ~> $cleanEnumSingle($allowedMaterialTypes) ~> $defaultValue("None/not available")
 };
 
+$getDatasetLinkage := function($outputField,$inputField) {
+    $defaultValue(
+        $outputField,
+        $map(
+            $split($inputField, ", "),
+            function($item) { 
+                {
+                    "pid": null, 
+                    "title": $contains($trim($item), "http") ? null : $trim($item), 
+                    "url": $contains($trim($item), "http") ? $trim($item) : null 
+                } 
+            }
+        )
+    )
+};
+
 $isValidString := function($str) { $type($str) = "string" and $str != null and $str != "" };
 $isValidArray := function($arr) { $type($arr) = "array"  };
 
@@ -345,6 +361,8 @@ $cleanEnum := function($x, $allowed){
 $cleanEnumSingle := function($x, $allowed){
     $tryMatchEnum($x, $allowed)
 };
+
+
 
 
 {
@@ -414,10 +432,10 @@ $cleanEnumSingle := function($x, $allowed){
     "enrichmentAndLinkage": input.linkage ~> |$|{
         "tools": $defaultValue($$.extra.linkages.tools, tools ~> $safeSplit(";,;")) ~> $nullList,
         "investigations": $defaultValue($$.extra.linkages.investigations, investigations ~> $safeSplit(";,;")) ~> $nullList,
-        "derivedFrom": $defaultValue($$.extra.linkages.derivedFrom, isDerivedFrom ~> $safeSplit(";,;")) ~> $nullList,
-        "isPartOf": $defaultValue($$.extra.linkages.derivedFrom, isPartOf),
-        "linkableDatasets": $defaultValue($$.extra.linkages.linkableDatasets, linkedDatasets),
-        "similarToDatasets": $defaultValue($$.extra.linkages.similarToDatasets, isMemberOf)
+        "derivedFrom": $getDatasetLinkage($$.extra.linkages.derivedFrom,datasetLinkage.isDerivedFrom),
+        "isPartOf": $getDatasetLinkage($$.extra.linkages.isPartOf,datasetLinkage.isPartOf),
+        "linkableDatasets": $getDatasetLinkage($$.extra.linkages.linkableDatasets,datasetLinkage.linkedDatasets),
+        "similarToDatasets": $getDatasetLinkage($$.extra.linkages.similarToDatasets,datasetLinkage.isMemberOf)
     }, ['dataUses','isGeneratedUsing','associatedMedia','isReferenceIn','syntheticDataWebLink','datasetLinkage']|,
     "observations": input.observations ~> $defaultValue([]),
     "structuralMetadata": {

--- a/maps/HDRUK/3.0.0/GWDM/2.0/translation.jsonata
+++ b/maps/HDRUK/3.0.0/GWDM/2.0/translation.jsonata
@@ -322,7 +322,7 @@ $getDatasetLinkage := function($outputField,$inputField) {
     $defaultValue(
         $outputField,
         $map(
-            $split($inputField, ", "),
+            $split($inputField, ";,;"),
             function($item) { 
                 {
                     "pid": null, 


### PR DESCRIPTION
Changed handling of linked datasets objects. The following code assumes a string but an array of strings is passed:

```
$getDatasetLinkage := function(){(
    $datasetLinkage := {
      "isDerivedFrom":$to_str(input.enrichmentAndLinkage.derivedFrom),
      "isPartOf":$to_str(input.enrichmentAndLinkage.isPartOf),
      "isMemberOf": $to_str(input.enrichmentAndLinkage.similarToDatasets),
      "linkedDatasets":$to_str(input.enrichmentAndLinkage.linkableDatasets)
    };
    $datasetLinkage = {} ? null : $datasetLinkage
)};
```

Effective unlisting of the array fixes the JSONata. 

Also implemented the reverse logic, but it is slightly lossy. If a its a url the url field is populated, otherwise the title field is populated. there is no way to distinguish between PIDs and titles. 