### PR TITLE
fix -dataset linkage null

### DIFF
--- a/maps/GWDM/2.0/HDRUK/3.0.0/translation.jsonata
+++ b/maps/GWDM/2.0/HDRUK/3.0.0/translation.jsonata
@@ -33,7 +33,10 @@ $getDatasetLinkage := function() {
       "isPartOf": input.enrichmentAndLinkage.isPartOf,
       "isMemberOf": input.enrichmentAndLinkage.similarToDatasets,
       "linkedDatasets": input.enrichmentAndLinkage.linkableDatasets
-    }
+    },
+
+    $isEmpty := $datasetLinkage.isDerivedFrom = null and $datasetLinkage.isPartOf = null and $datasetLinkage.isMemberOf = null and $datasetLinkage.linkedDatasets = null,
+    $result := $isEmpty ? null : $datasetLinkage
   )
 };
 


### PR DESCRIPTION
so php when using: `$response->json()` will translate empty objects into arrays: [see docs](https://www.php.net/manual/en/json.constants.php#constant.json-force-object),

We want schema to return us null not an empty object

