### PR TITLE
fix(GAT-8923): Fix for translation.jsonata for GWDM 2.0 -> HDRUK 4.0.0

### DIFF
--- a/maps/HDRUK/4.0.0/GWDM/2.0/translation.jsonata
+++ b/maps/HDRUK/4.0.0/GWDM/2.0/translation.jsonata
@@ -439,7 +439,7 @@ $cleanEnumSingle := function($x, $allowed){
         "usage": usage ? usage ~> |$|{
             "dataUseRequirements": $safeSplit(dataUseRequirement,";,;") ~> $cleanEnum($allowedDataUseRequirements) ~> $defaultValue(null),
             "dataUseLimitation": $safeSplit(dataUseLimitation,";,;") ~> $cleanEnum($allowedDataUseLimitation) ~> $defaultValue(null),
-            "resourceCreator": resourceCreator.name ~> $safeSplit(";,;")
+            "resourceCreator": $resourceCreator.name ~> $safeSplit(";,;") ~> $join(", ")
         }, ['dataUseRequirement']|,
         "formatAndStandards": formatAndStandards ? formatAndStandards ~> |$|{
             "vocabularyEncodingScheme": vocabularyEncodingSchemes ?

--- a/maps/HDRUK/4.0.0/GWDM/2.0/translation.jsonata
+++ b/maps/HDRUK/4.0.0/GWDM/2.0/translation.jsonata
@@ -439,7 +439,7 @@ $cleanEnumSingle := function($x, $allowed){
         "usage": usage ? usage ~> |$|{
             "dataUseRequirements": $safeSplit(dataUseRequirement,";,;") ~> $cleanEnum($allowedDataUseRequirements) ~> $defaultValue(null),
             "dataUseLimitation": $safeSplit(dataUseLimitation,";,;") ~> $cleanEnum($allowedDataUseLimitation) ~> $defaultValue(null),
-            "resourceCreator": $resourceCreator.name ~> $safeSplit(";,;") ~> $join(", ")
+            "resourceCreator": resourceCreator.name ~> $safeSplit(";,;") ~> $join(", ")
         }, ['dataUseRequirement']|,
         "formatAndStandards": formatAndStandards ? formatAndStandards ~> |$|{
             "vocabularyEncodingScheme": vocabularyEncodingSchemes ?

--- a/maps/HDRUK/4.0.0/GWDM/2.0/translation.jsonata
+++ b/maps/HDRUK/4.0.0/GWDM/2.0/translation.jsonata
@@ -439,7 +439,7 @@ $cleanEnumSingle := function($x, $allowed){
         "usage": usage ? usage ~> |$|{
             "dataUseRequirements": $safeSplit(dataUseRequirement,";,;") ~> $cleanEnum($allowedDataUseRequirements) ~> $defaultValue(null),
             "dataUseLimitation": $safeSplit(dataUseLimitation,";,;") ~> $cleanEnum($allowedDataUseLimitation) ~> $defaultValue(null),
-            "resourceCreator": resourceCreator.name
+            "resourceCreator": resourceCreator.name ~> $safeSplit(";,;")
         }, ['dataUseRequirement']|,
         "formatAndStandards": formatAndStandards ? formatAndStandards ~> |$|{
             "vocabularyEncodingScheme": vocabularyEncodingSchemes ?


### PR DESCRIPTION
* Resource creator can be a list, so it should be split:
https://github.com/HDRUK/schemata/blob/dev/hdr_schemata/models/HDRUK/v3_0_0/Usage.py#L24